### PR TITLE
Fix bug: call to undefined function varnish()

### DIFF
--- a/src/Commands/FlushVarnishCache.php
+++ b/src/Commands/FlushVarnishCache.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Varnish\Commands;
 
-use Illuminate\Console\Command;
 use Spatie\Varnish\Varnish;
+use Illuminate\Console\Command;
 
 class FlushVarnishCache extends Command
 {

--- a/src/Commands/FlushVarnishCache.php
+++ b/src/Commands/FlushVarnishCache.php
@@ -3,6 +3,7 @@
 namespace Spatie\Varnish\Commands;
 
 use Illuminate\Console\Command;
+use Spatie\Varnish\Varnish;
 
 class FlushVarnishCache extends Command
 {
@@ -27,7 +28,7 @@ class FlushVarnishCache extends Command
      */
     public function handle()
     {
-        varnish()->flush();
+        (new Varnish())->flush();
 
         $this->comment('The varnish cache has been flushed!');
     }


### PR DESCRIPTION
When running the initial version on the command line 
```
php artisan varnish:flush
```

I got:
```
  [Symfony\Component\Debug\Exception\FatalThrowableError]
  Call to undefined function Spatie\Varnish\Commands\varnish()
```

This is with php version:
PHP 7.1.0 (cli) (built: Dec  2 2016 11:32:42) ( NTS )