### PR TITLE
Lumen support added.

### DIFF
--- a/src/VarnishServiceProvider.php
+++ b/src/VarnishServiceProvider.php
@@ -10,9 +10,13 @@ class VarnishServiceProvider extends ServiceProvider
     public function boot()
     {
         if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../config/varnish.php' => config_path('varnish.php'),
-            ], 'config');
+            $configPath = __DIR__ . '/../config/varnish.php';
+            if (function_exists('config_path')) {
+                $publishPath = config_path('varnish.php');
+            } else {
+                $publishPath = base_path('config/varnish.php');
+            }
+            $this->publishes([$configPath => $publishPath], 'config');
         }
     }
 


### PR DESCRIPTION
As it's mentioned in #26, Lumen does not provide `config_path` function. This change solves the issue.