### PR TITLE
fix: #46 #48

### DIFF
--- a/src/Varnish.php
+++ b/src/Varnish.php
@@ -43,7 +43,7 @@ class Varnish
      * @param string $url
      * @return string
      */
-    public function generateBanCommand(array $hosts, string $url = null): string
+    public function generateBanCommand(array $hosts, string $url = null): array
     {
         $hostsRegex = collect($hosts)
             ->map(function (string $host) {
@@ -58,10 +58,18 @@ class Varnish
             $urlRegex = " && req.url ~ {$url}";
         }
 
-        return "sudo varnishadm -S {$config['administrative_secret']} -T 127.0.0.1:{$config['administrative_port']} 'ban req.http.host ~ {$hostsRegex}{$urlRegex}'";
+        return [
+            '/usr/bin/sudo',
+            'varnishadm',
+            '-S',
+            $config['administrative_secret'],
+            '-T',
+            "127.0.0.1:{$config['administrative_port']}",
+            "\"ban req.http.host ~ {$hostsRegex}{$urlRegex}\""
+        ];
     }
 
-    protected function executeCommand(string $command): Process
+    protected function executeCommand(array $command): Process
     {
         $process = new Process($command);
 

--- a/tests/VarnishTest.php
+++ b/tests/VarnishTest.php
@@ -9,7 +9,15 @@ class VarnishTest extends TestCase
     /** @test */
     public function it_can_generate_a_ban_command_for_a_single_host()
     {
-        $expectedCommand = "sudo varnishadm -S /etc/varnish/secret -T 127.0.0.1:6082 'ban req.http.host ~ (^example.com$)'";
+        $expectedCommand = [
+            '/usr/bin/sudo',
+            'varnishadm',
+            '-S',
+            '/etc/varnish/secret',
+            '-T',
+            "127.0.0.1:6082",
+            "\"ban req.http.host ~ (^example.com$)\""
+        ];
 
         $this->assertEquals($expectedCommand, (new Varnish())->generateBanCommand(['example.com']));
     }
@@ -23,7 +31,15 @@ class VarnishTest extends TestCase
         $this->app['config']->set('varnish.administrative_secret', $secret);
         $this->app['config']->set('varnish.administrative_port', $port);
 
-        $expectedCommand = "sudo varnishadm -S {$secret} -T 127.0.0.1:{$port} 'ban req.http.host ~ (^example.com$)'";
+        $expectedCommand = [
+            '/usr/bin/sudo',
+            'varnishadm',
+            '-S',
+            $secret,
+            '-T',
+            "127.0.0.1:{$port}",
+            "\"ban req.http.host ~ (^example.com$)\""
+        ];
 
         $this->assertEquals($expectedCommand, (new Varnish())->generateBanCommand(['example.com']));
     }
@@ -31,7 +47,15 @@ class VarnishTest extends TestCase
     /** @test */
     public function it_can_generate_a_ban_command_for_multiple_hosts()
     {
-        $expectedCommand = "sudo varnishadm -S /etc/varnish/secret -T 127.0.0.1:6082 'ban req.http.host ~ (^example.com$)|(^example2.com$)'";
+        $expectedCommand = [
+            '/usr/bin/sudo',
+            'varnishadm',
+            '-S',
+            '/etc/varnish/secret',
+            '-T',
+            "127.0.0.1:6082",
+            "\"ban req.http.host ~ (^example.com$)|(^example2.com$)\""
+        ];
 
         $this->assertEquals($expectedCommand, (new Varnish())->generateBanCommand([
             'example.com',
@@ -42,7 +66,15 @@ class VarnishTest extends TestCase
     /** @test */
     public function it_can_generate_a_ban_command_for_a_single_host_and_a_specific_url()
     {
-        $expectedCommand = "sudo varnishadm -S /etc/varnish/secret -T 127.0.0.1:6082 'ban req.http.host ~ (^example.com$) && req.url ~ /nl/*'";
+        $expectedCommand = [
+            '/usr/bin/sudo',
+            'varnishadm',
+            '-S',
+            '/etc/varnish/secret',
+            '-T',
+            "127.0.0.1:6082",
+            "\"ban req.http.host ~ (^example.com$) && req.url ~ /nl/*\""
+        ];
 
         $this->assertEquals($expectedCommand, (new Varnish())->generateBanCommand(['example.com'], '/nl/*'));
     }
@@ -50,7 +82,15 @@ class VarnishTest extends TestCase
     /** @test */
     public function it_can_generate_a_ban_command_for_multiple_hosts_and_a_specific_url()
     {
-        $expectedCommand = "sudo varnishadm -S /etc/varnish/secret -T 127.0.0.1:6082 'ban req.http.host ~ (^example.com$)|(^example2.com$) && req.url ~ /nl/*'";
+        $expectedCommand = [
+            '/usr/bin/sudo',
+            'varnishadm',
+            '-S',
+            '/etc/varnish/secret',
+            '-T',
+            "127.0.0.1:6082",
+            "\"ban req.http.host ~ (^example.com$)|(^example2.com$) && req.url ~ /nl/*\""
+        ];
 
         $this->assertEquals($expectedCommand, (new Varnish())->generateBanCommand([
             'example.com',


### PR DESCRIPTION
I received a `command not found error` with `sudo` so used `/usr/bin/sudo` instead.
Also the process component escapes the `'` character so I had to replace it with `"`.

Please let me know if it needs any changes.