### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: spatie
 custom: https://spatie.be/open-source/support-us

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,29 +1,23 @@
 name: Check & fix styling
 
-on: [push]
+on: [ push ]
 
 jobs:
-    style:
+    php-cs-fixer:
         runs-on: ubuntu-latest
 
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
+                with:
+                    ref: ${{ github.head_ref }}
 
-            -   name: Fix style
+            -   name: Run PHP CS Fixer
                 uses: docker://oskarstark/php-cs-fixer-ga
                 with:
-                    args: --config=.php_cs --allow-risky=yes
-
-            -   name: Extract branch name
-                shell: bash
-                run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-                id: extract_branch
+                    args: --config=.php-cs-fixer.dist.php --allow-risky=yes
 
             -   name: Commit changes
-                uses: stefanzweifel/git-auto-commit-action@v2.3.0
+                uses: stefanzweifel/git-auto-commit-action@v4
                 with:
                     commit_message: Fix styling
-                    branch: ${{ steps.extract_branch.outputs.branch }}
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,19 +9,12 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.0, 7.4, 7.3, 7.2]
-                laravel: [6.*, 7.*, 8.*]
+                php: [8.1, 8.0, 7.4]
+                laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
-                        testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
-                exclude:
-                    -   laravel: 8.*
-                        php: 7.2
+                        testbench: ^6.23
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ build
 composer.lock
 docs
 vendor
-.php_cs.cache
+*.cache
+

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,7 +3,7 @@
 $finder = Symfony\Component\Finder\Finder::create()
     ->notPath('bootstrap/*')
     ->notPath('storage/*')
-    ->notPath('vendor')
+    ->notPath('resources/view/mail/*')
     ->in([
         __DIR__ . '/src',
         __DIR__ . '/tests',
@@ -13,14 +13,14 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config)
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,
@@ -29,11 +29,6 @@ return PhpCsFixer\Config::create()
         ],
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_var_without_name' => true,
-        'class_attributes_separation' => [
-            'elements' => [
-                'method', 'property',
-            ],
-        ],
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
             'keep_multiple_spaces_after_comma' => true,

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/http": "^6.0|^7.0|^8.0"
+        "php": "^7.4|^8.0",
+        "illuminate/console": "^8.73",
+        "illuminate/http": "^8.73"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0",
-        "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0"
+        "phpunit/phpunit": "^9.4",
+        "orchestra/testbench": "^6.23"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Spatie Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    verbose="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Spatie Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>


### PR DESCRIPTION
This PR adds support for PHP 8.1 to the tests workflow.  Additionally, it:
- drops support for PHP < 7.4
- drops support for Laravel < 8.x
- updates the `php-cs-fixer` workflow and config file
- updates the `PHPUnit` config file to be in line with other packages
- adds the update changelog workflow

_This repository needs its primary branch renamed from `master` to `main`._