### PR TITLE
s-maxage is the correct header

### DIFF
--- a/src/Middleware/CacheWithVarnish.php
+++ b/src/Middleware/CacheWithVarnish.php
@@ -12,7 +12,7 @@ class CacheWithVarnish
 
         return $response->withHeaders([
             config('varnish.cacheable_header_name') => '1',
-            'Cache-Control' => 'public, max-age='. 60 * ($cacheTimeInMinutes ?? config('varnish.cache_time_in_minutes')),
+            'Cache-Control' => 'public, s-maxage='. 60 * ($cacheTimeInMinutes ?? config('varnish.cache_time_in_minutes')),
         ]);
     }
 }


### PR DESCRIPTION
Because it dictates cache lifetime in Varnish only, not in the clients.