### PR TITLE
Changed initialization of Symfony\Component\Process\Process class 

### DIFF
--- a/src/Varnish.php
+++ b/src/Varnish.php
@@ -63,7 +63,7 @@ class Varnish
 
     protected function executeCommand(string $command): Process
     {
-        $process = new Process($command);
+        $process = new Process([$command]);
 
         $process->run();
 


### PR DESCRIPTION
Symphony's process class initialization was failing because it no longer accepts string in it's constructor, so I switched it to array. 