### PR TITLE
use setSharedMaxAge function

### DIFF
--- a/src/Middleware/CacheWithVarnish.php
+++ b/src/Middleware/CacheWithVarnish.php
@@ -10,9 +10,10 @@ class CacheWithVarnish
     {
         $response = $next($request);
 
-        return $response->withHeaders([
-            config('varnish.cacheable_header_name') => '1',
-            'Cache-Control' => 'public, s-maxage='. 60 * ($cacheTimeInMinutes ?? config('varnish.cache_time_in_minutes')),
-        ]);
+        return $response
+            ->withHeaders([
+                config('varnish.cacheable_header_name') => '1',
+            ])
+            ->setSharedMaxAge(60 * ($cacheTimeInMinutes ?? config('varnish.cache_time_in_minutes')));
     }
 }


### PR DESCRIPTION
This small change will make sure we don't fully override all aspects of the cache-control header.

This uses the underlying function of a symfony response:
https://github.com/symfony/symfony/blob/d549e9c0351652b751228df78ef01284e9f97343/src/Symfony/Component/HttpFoundation/Response.php#L836C21-L836C36

Which sets it to public and sets s-maxage
But now settings like stale-while-revalidate, maxage and others will not get overridden. Instead being added to. If set elsewhere