### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.4, 8.0, 8.1, '8.2']
+        php: [8.5, 8.2, 8.1, 8.0, 7.4]
         laravel: ['8.*', '9.*', '10.*', '11.*', '12.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
@@ -60,6 +60,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
+        shell: bash
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,69 +1,49 @@
 name: run-tests
 
-on:
-  - push
-  - pull_request
+on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.5, 8.2, 8.1, 8.0, 7.4]
-        laravel: ['8.*', '9.*', '10.*', '11.*', '12.*']
-        dependency-version: [prefer-lowest, prefer-stable]
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: ['13.*', '12.*', '11.*', '10.*']
+        stability: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: ^6.23
-          - laravel: 11.*
-            testbench: 9.*
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 10.*
+            testbench: 8.*
         exclude:
+          - laravel: 13.*
+            php: 8.2
           - laravel: 10.*
-            php: 8.0
-          - laravel: 10.*
-            php: 7.4
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 11.*
-            php: 7.4
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 7.4
-          - laravel: 12.*
-            php: 8.0
-          - laravel: 12.*
-            php: 8.1
+            php: 8.5
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, fileinfo, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
       - name: Install dependencies
-        shell: bash
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/console": "^8.73|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/http": "^8.73|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/console": "^8.73|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/http": "^8.73|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0",
-        "pestphp/pest": "^1.22|^2.34|^3.7",
-        "phpunit/phpunit": "^9.5|^10.5|^11.5.3"
+        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^1.22|^2.34|^3.7|^4.0",
+        "phpunit/phpunit": "^9.5|^10.5|^11.5.3|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,9 +5,6 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
   <source>
     <include>
       <directory suffix=".php">src/</directory>


### PR DESCRIPTION
## Summary
- Add Laravel 13 support
- Add PHP 8.5 to test matrix
- Fix coverage warnings
- Update test dependencies (Pest 4, PHPUnit 12, Testbench 11)